### PR TITLE
fix log file path, module import and icon

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 import sys
 
-with Path("C:\\Users\\User\\Desktop\\kleplace.log").open("w") as f:
-    f.write("Hello World\n")
+with Path("kleplace.log").open("w") as f:
     sys.path.append(str(Path(__file__).absolute().parent / "lib"))
     try:
         from .placement_plugin import KLEPlacementPlugin

--- a/placement_plugin.py
+++ b/placement_plugin.py
@@ -13,7 +13,7 @@ from typing import Callable, Dict, List, Tuple
 import pcbnew
 import wx
 
-from KLEPlacement.simplekleparser import KeySpec
+from .simplekleparser import KeySpec
 
 from .cfgman import ConfigMan
 from .interface.DlgKLEP import DlgKLEP

--- a/placement_plugin.py
+++ b/placement_plugin.py
@@ -34,7 +34,7 @@ class KLEPlacementPlugin(pcbnew.ActionPlugin):
         self.name = "KLE Placement"
         self.category = "Layout"
         self.description = "Place footprints according to a KLE layout. Paste in your unmodified KLE plugin and hit the run button!"
-        self.icon_file_name = str(Path(__file__).parent / "place_icon.png")
+        self.icon_file_name = str(Path(__file__).parent / "keyboard.png")
         self.show_toolbar_button = True
 
     def Run(self):


### PR DESCRIPTION
The log file path is windows specific.
With the fix the log file is now created in the current directory where KiCAD is launched, which makes more sense.

Also the Hello World output into the log file is probably not necessary.